### PR TITLE
Add rds instances

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ If your project has not been set up in Beanstalk yet you will have to ``bootstra
 This will create:
 
 - An `S3 bucket`_ for storing `application versions <#application-version>`_
-- An `Beanstalk application`_ named after the Github repo
+- A `Beanstalk application`_ named after the Github repo
 - A `Beanstalk configuration template <#configuration-template>`_ named ``default``
 
 For each environment it will create:

--- a/README.rst
+++ b/README.rst
@@ -30,15 +30,24 @@ Bootstrapping
 ~~~~~~~~~~~~~
 
 If this project has not been set up in Beanstalk yet you will have to ``bootstrap`` it.
-This will create an S3 bucket for storing the application packages and create a
-Beanstalk application with a two environments (one for staging, one for production)
-set to an initial version. A configuration template called ``default`` will also
-be created and used for both of the environments. Environment variables can be
-added to this configuration template from the current environment with the
-``--proxy-env`` argument. In the exmaple below the ``FOO`` and ``BAR``
-environment variables will be taken from the current environment and added to
-the configuration template. You do not need to provide an application name as that
-is taken from the git URL::
+It will create:
+
+- An S3 bucket for storing application packages
+- An Beanstalk application named after the Github repo
+- A Beanstalk configuration template named ``default``
+
+For each environment it will create:
+
+- A security group for the RDS instance named ``db-{app sha}-{environment name}``
+- An RDS instance named ``db-{app sha}-{environment name}``
+- A Beanstalk configuration template inheriting from ``default`` with the
+  RDS database details.
+- A Beanstalk environment named ``{app sha}-{environment name}``
+
+Environment variables can be added to the ``default`` configuration template from
+the current environment with the ``--proxy-env`` argument. In the example below the
+``FOO`` and ``BAR`` environment variables will be taken from the current
+environment and added to the configuration template.::
 
   dm-deploy bootstrap --proxy-env='FOO,BAR'
 
@@ -46,9 +55,9 @@ Ephemeral environments
 ~~~~~~~~~~~~~~~~~~~~~~
 
 To create an ephemeral environment for a feature branch use the 
-``deploy-to-branch-environment`` command. This will create a development version
-and a development environment with that version. If a branch is not explicitly
-provided then the current branch name will be used::
+``deploy-to-branch-environment`` command. This will create a development version,
+a development environment with that version and an associated RDS instance. If
+a branch is not explicitly provided then the current branch name will be used::
 
   dm-deploy deploy-to-branch-environment
 
@@ -67,7 +76,7 @@ The new version will be created from the current ``HEAD``::
 
   dm-deploy create-version release-1234
 
-Once we have a version label of the form `release-{ something }` we can deploy
+Once we have a version label of the form ``release-{ something }`` we can deploy
 it to staging and production. The following command will deploy the most recent
 'release' version to the staging environment::
 
@@ -82,41 +91,87 @@ production::
 AWS Elements
 ------------
 
-The `Beanstalk application`_ is named the same as the github repository; it is
-derived from the git remote origin URL.
+Beanstalk application
+~~~~~~~~~~~~~~~~~~~~~
+
+`AWS documentation <http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#application>`_
+
+Named the same as the Github application; it is derived from the git remote
+origin URL. Contains Beanstalk environments.
+
+S3 bucket
+~~~~~~~~~
+
+`AWS documentation <http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#bucket>`_
 
 For each application there is an `S3 bucket`_ with the same name used for
-storing the `application version`_ packages. Note that this S3 bucket must be
-in the same `AWS region`_ as the Beanstalk application. Packages are zip files
-at a point in the git tree. As such they are named after the full commit sha
-that they represent.
+storing the `Application version`_ packages.
+
+.. note::
+  This S3 bucket must be in the same `AWS region`_ as the Beanstalk application.
+
+Beanstalk environment
+~~~~~~~~~~~~~~~~~~~~~
+
+`AWS documentation <http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#environment>`_
+
+Beanstalk environments are named ``{app sha}-{environment short name}``.
+``{app sha}`` is a short unique identifier for the application, this is needed
+because environment names must be unique across all Beanstalk applications.
+``{environment short name}`` is the environment name we use; for example
+``staging`` or ``production`` for our permanent environments or ``dev-{label}``
+for ephemeral environments.
+
+Each environment has it's own RDS instance associated with it, see
+`RDS instance`_.
+
+Each environment has a configuration template called ``{environment name}``,
+see `Configuration template`_.
+
+RDS instance
+~~~~~~~~~~~~
+
+`AWS documentation <http://aws.amazon.com/rds/>`_
+
+An RDS instance is created for each environment and named ``db-{environment name}``.
+The associated Beanstalk environment is given access to this via a `Security group`_
+also called ``db-{environment name}``.
+
+.. note::
+  The RDS instance and security group are not otherwise tied to the Beanstalk
+  environment and therefore need to be manually removed or unlinked (via the
+  security group) from the environment before it is terminated.
+
+Configuration template
+~~~~~~~~~~~~~~~~~~~~~~
+
+`AWS documentation <http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-beanstalk-configurationtemplate.html>`_
 
 When a new application is bootstrapped a configuration template called
-``default`` is created and local environment variables can optionally be added
-to it. Then two `Beanstalk environments`_ are created. These are named
-``{app sha}-staging`` and ``{app sha}-production``. The ``{app sha}`` is a
-short unique identifier for the application. This is needed because Beanstalk
-environment names must be unique across all your applications. A new version
-called ``initial`` is created for these two new environments.
+``default`` is created and local environment variables can optionally be
+added to it. A configuration template inheriting from this one is also created
+for each environment which contains the RDS details (connection information
+and credentials).
 
-Subsequent versions can be named whatever you like, so long as the name has not
-already been used. Strangely version labels do not have to be unique across
-all your applications.
+Application version
+~~~~~~~~~~~~~~~~~~~
 
-Ephemeral environments can also be created for features or experiments. Usually
-these would be done from a feature branch but they do not have to be. When
-an application is deployed to a new ephemeral environment a new version label
-is created named ``dev-{label}-{short commit sha}``. The ``{label}`` is set to the
-branch name if none is provided and the ``{short commit sha}`` is the commit sha
-truncated to 7 characters. An environment is also created (or updated if it
-already exists) with the name ``{app sha}-dev-{label}`` where the ``{app sha}`` is
-the same as for the staging and production environments and the ``{label}`` is
-the same as for the version label.
+`AWS documentation <http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#appversion>`_
+
+An application version is a package (zip file stored in S3) containing
+application code with an associated version label. The package files are named
+after the full git commit sha that they represent. When bootstrapping an
+application a version called ``initial`` is created all other versions are
+named as follows:
+
+- Release versions should be called ``release-{build number}``.
+- Ephemeral versions will be called ``dev-{label}-{short commit sha}``.
+
+.. note::
+  Version names have a length limit of 100 characters.
+
 
 .. _boto: https://github.com/boto/boto
 .. _config tutorial: http://boto.readthedocs.org/en/latest/boto_config_tut.html
-.. _S3 bucket: http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#bucket
-.. _Beanstalk application: http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#application
-.. _application version: http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#appversion
 .. _AWS region: http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#region
-.. _Beanstalk environments: http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#environment
+.. _Security group: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html

--- a/README.rst
+++ b/README.rst
@@ -29,25 +29,25 @@ Navigate into the project you want to deploy::
 Bootstrapping
 ~~~~~~~~~~~~~
 
-If this project has not been set up in Beanstalk yet you will have to ``bootstrap`` it.
-It will create:
+If your project has not been set up in Beanstalk yet you will have to ``bootstrap`` it.
+This will create:
 
-- An S3 bucket for storing application packages
-- An Beanstalk application named after the Github repo
-- A Beanstalk configuration template named ``default``
+- An `S3 bucket`_ for storing `application versions <#application-version>`_
+- An `Beanstalk application`_ named after the Github repo
+- A `Beanstalk configuration template <#configuration-template>`_ named ``default``
 
 For each environment it will create:
 
-- A security group for the RDS instance named ``db-{app sha}-{environment name}``
-- An RDS instance named ``db-{app sha}-{environment name}``
-- A Beanstalk configuration template inheriting from ``default`` with the
+- A security group for the `RDS instance`_ named ``db-{app sha}-{environment name}``
+- An `RDS instance`_ named ``db-{app sha}-{environment name}``
+- A `Beanstalk configuration template <#configuration-template>`_ inheriting from ``default`` with the
   RDS database details.
-- A Beanstalk environment named ``{app sha}-{environment name}``
+- A `Beanstalk environment`_ named ``{app sha}-{environment name}``
 
 Environment variables can be added to the ``default`` configuration template from
 the current environment with the ``--proxy-env`` argument. In the example below the
 ``FOO`` and ``BAR`` environment variables will be taken from the current
-environment and added to the configuration template.::
+environment and added to the configuration template::
 
   dm-deploy bootstrap --proxy-env='FOO,BAR'
 
@@ -97,15 +97,15 @@ Beanstalk application
 `AWS documentation <http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#application>`_
 
 Named the same as the Github application; it is derived from the git remote
-origin URL. Contains Beanstalk environments.
+origin URL. Contains `Beanstalk environments <#beanstalk-environment>`_.
 
 S3 bucket
 ~~~~~~~~~
 
 `AWS documentation <http://docs.aws.amazon.com/general/latest/gr/glos-chap.html#bucket>`_
 
-For each application there is an `S3 bucket`_ with the same name used for
-storing the `Application version`_ packages.
+For each application there is an S3 bucket with the same name as the application
+used for storing the `Application version`_ packages.
 
 .. note::
   This S3 bucket must be in the same `AWS region`_ as the Beanstalk application.

--- a/digitalmarketplace/deploy/aws.py
+++ b/digitalmarketplace/deploy/aws.py
@@ -185,10 +185,7 @@ class S3Client(object):
     def __init__(self, region, **kwargs):
         self._region = region
         self._options = kwargs
-        self._connection = self._get_connection(region)
-
-    def _get_connection(self, region):
-        return s3.connect_to_region(region)
+        self._connection = s3.connect_to_region(region)
 
     def create_bucket(self, application_name):
         logging.info("Creating S3 bucket {} in region {}".format(
@@ -217,16 +214,13 @@ class BeanstalkClient(object):
     def __init__(self, region, **kwargs):
         self._region = region
         self._options = kwargs
-        self._connection = self._get_connection(region)
+        self._connection = beanstalk.connect_to_region(region)
         self._ec2 = EC2Client(region)
 
     @property
     def solution_stack_name(self):
         return self._options.get(
             'solution_stack_name', DEFAULT_SOLUTION_STACK)
-
-    def _get_connection(self, region):
-        return beanstalk.connect_to_region(region)
 
     def create_application(self, application_name):
         logging.info("Creating Beanstalk application {}".format(

--- a/digitalmarketplace/deploy/aws.py
+++ b/digitalmarketplace/deploy/aws.py
@@ -3,8 +3,9 @@ import os.path
 import hashlib
 import logging
 import re
+import time
 
-from boto import beanstalk, s3
+from boto import beanstalk, ec2, s3, rds2
 from boto.s3.key import Key
 from boto.exception import S3CreateError, BotoServerError
 
@@ -12,9 +13,13 @@ from . import git
 
 
 DEFAULT_SOLUTION_STACK = '64bit Amazon Linux 2014.03 v1.0.9 running Python 2.7'
+DEFAULT_ENVIRONMENT_NAMES = ['staging', 'production']
 
 
 def get_client(region):
+    """
+    :rtype: Client
+    """
     return Client(region)
 
 
@@ -24,30 +29,28 @@ class Client(object):
     def __init__(self, region):
         self.s3 = S3Client(region)
         self.beanstalk = BeanstalkClient(region)
+        self.ec2 = EC2Client(region)
+        self.rds = RDSClient(region)
         self.application_name = git.get_application_name()
 
-    def create_configuration(self, proxy_env):
-        option_name = 'aws:elasticbeanstalk:application:environment'
-        option_settings = [
-            (option_name, env_name, os.environ[env_name])
-            for env_name in proxy_env]
-
-        self.beanstalk.create_configuration_template(
-            self.application_name, 'default',
-            DEFAULT_SOLUTION_STACK, option_settings)
-
-    def bootstrap(self, proxy_env):
+    def bootstrap(self, proxy_env, db_name, db_username, db_password):
         """Bootstrap a new application"""
         self.s3.create_bucket(self.application_name)
         self.beanstalk.create_application(self.application_name)
-        self.create_configuration(proxy_env)
+        self.beanstalk.create_configuration_template(
+            self.application_name, 'default',
+            solution_stack=DEFAULT_SOLUTION_STACK,
+            environ=dict(
+                (env_name, os.environ[env_name]) for env_name in proxy_env))
 
         version_label = self.create_version(
             'initial',
             description='Initial code version for bootstrap')
-        for environment_name in ['staging', 'production']:
-            self.beanstalk.create_environment(
-                self.application_name, environment_name, version_label)
+
+        for environment_short_name in DEFAULT_ENVIRONMENT_NAMES:
+            environment_name = self._get_env_name(environment_short_name)
+            self._create_environment(environment_name, db_name,
+                                     db_username, db_password, version_label)
 
     def create_version(self, version_label, with_sha=False, description=''):
         sha, package_path = git.create_package()
@@ -61,20 +64,82 @@ class Client(object):
             description)
         return version_label
 
-    def deploy_to_branch_environment(self, branch):
-        environment_name = 'dev-{}'.format(branch)
-        version_label = self.create_version(environment_name, with_sha=True)
-        self.beanstalk.create_or_update_environment(
-            self.application_name, environment_name, version_label)
+    def deploy_to_branch_environment(self, branch, db_name, db_username,
+                                     db_password):
+        environment_short_name = 'dev-{}'.format(branch)
+        environment_name = self._get_env_name(environment_short_name)
+        version_label = self.create_version(
+            environment_short_name, with_sha=True)
+
+        if self.rds.get_security_group(environment_name) is None:
+            self._create_environment(environment_name, db_name,
+                                     db_username, db_password, version_label)
+        else:
+            self.beanstalk.update_environment(environment_name,
+                                              version_label)
 
     def terminate_branch_environment(self, branch):
-        environment_name = 'dev-{}'.format(branch)
-        self.beanstalk.terminate_environment(
-            self.application_name, environment_name)
+        environment_short_name = 'dev-{}'.format(branch)
+        environment_name = self._get_env_name(environment_short_name)
 
-    def deploy(self, version_label, environment_name):
-        self.beanstalk.update_environment(
-            self.application_name, environment_name, version_label)
+        self.beanstalk.terminate_environment(environment_name)
+
+        self.beanstalk.delete_configuration_template(self.application_name,
+                                                     environment_name)
+
+        self.rds.delete_dbinstance(environment_name)
+
+    def _create_environment(self, environment_name, db_name, db_username,
+                            db_password, version_label):
+        db_uri = self._create_rds_instance(environment_name, db_name,
+                                           db_username, db_password)
+        self._create_beanstalk_environment(environment_name, db_uri,
+                                           version_label)
+
+    def _create_rds_instance(self, environment_name, db_name, db_username,
+                             db_password):
+        logging.info("Creating RDS instance for {}".format(environment_name))
+        dbinstance = self.rds.create_dbinstance(environment_name, db_name,
+                                                db_username, db_password)
+        logging.info("Waiting for RDS instance to start")
+        dbinstance = self.rds.wait_for_endpoint(dbinstance)
+        endpoint_address = dbinstance['Endpoint']['Address']
+        endpoint_port = dbinstance['Endpoint']['Port']
+        db_uri = 'postgres://{}:{}@{}:{}/{}'.format(db_username, db_password,
+                                                    endpoint_address,
+                                                    endpoint_port,
+                                                    db_name)
+
+        return db_uri
+
+    def _create_beanstalk_environment(self, environment_name, db_uri,
+                                      version_label):
+        logging.info("Creating Beanstalk environment for {}".format(
+            environment_name))
+        self.beanstalk.create_configuration_template(
+            self.application_name, environment_name,
+            source_configuration='default',
+            environ={
+                'SQLALCHEMY_DATABASE_URI': db_uri
+            })
+        self.beanstalk.create_environment(
+            self.application_name, environment_name, version_label,
+            template_name=environment_name)
+
+        logging.info("Giving Beanstalk environment access to RDS instance")
+        rds_security_group = self.rds.get_security_group(environment_name)
+        self.beanstalk.wait_for_security_group(environment_name)
+        eb_security_group = self.beanstalk.get_security_group(environment_name)
+
+        rds_security_group.authorize(
+            ip_protocol='tcp',
+            from_port=5432,
+            to_port=5432,
+            src_group=eb_security_group)
+
+    def deploy(self, version_label, environment_short_name):
+        environment_name = self._get_env_name(environment_short_name)
+        self.beanstalk.update_environment(environment_name, version_label)
 
     def deploy_latest_to_staging(self):
         version_label = self.get_latest_release_version()
@@ -99,9 +164,21 @@ class Client(object):
         self.deploy(version_label, 'production')
 
     def get_current_staging_version(self):
-        staging = self.beanstalk.describe_environment(
-            self.application_name, 'staging')
+        environment_name = self._get_env_name('staging')
+        staging = self.beanstalk.describe_environment(self.application_name,
+                                                      environment_name)
         return staging['VersionLabel']
+
+    def _get_env_name(self, environment_short_name):
+        """Return an environment name
+
+        Generate an environment name from the application name and
+        an environment name. Amazon Beanstalk requires environment names to
+        be unique across applications so the application name must be
+        encoded into the environment name.
+        """
+        application_hash = hashlib.sha1(self.application_name).hexdigest()[:5]
+        return '{}-{}'.format(application_hash, environment_short_name)
 
 
 class S3Client(object):
@@ -114,6 +191,8 @@ class S3Client(object):
         return s3.connect_to_region(region)
 
     def create_bucket(self, application_name):
+        logging.info("Creating S3 bucket {} in region {}".format(
+            application_name, self._region))
         if self._region.startswith('eu'):
             location = 'EU'
         else:
@@ -139,6 +218,7 @@ class BeanstalkClient(object):
         self._region = region
         self._options = kwargs
         self._connection = self._get_connection(region)
+        self._ec2 = EC2Client(region)
 
     @property
     def solution_stack_name(self):
@@ -149,6 +229,8 @@ class BeanstalkClient(object):
         return beanstalk.connect_to_region(region)
 
     def create_application(self, application_name):
+        logging.info("Creating Beanstalk application {}".format(
+            application_name))
         try:
             self._connection.create_application(application_name)
         except BotoServerError as e:
@@ -158,35 +240,52 @@ class BeanstalkClient(object):
                 raise
 
     def create_environment(self, application_name, environment_name,
-                           version_label):
-        environment_name = self._environment_name(
-            application_name, environment_name)
+                           version_label, template_name):
         self._connection.create_environment(
             application_name, environment_name, version_label,
-            template_name='default')
+            template_name=template_name)
 
     def create_configuration_template(self, application_name, template_name,
-                                      solution_stack_name, option_settings):
+                                      solution_stack=None,
+                                      source_configuration=None,
+                                      option_settings=None,
+                                      environ=None):
+        logging.info(
+            "Creating Beanstalk configuration template {} in {}".format(
+                template_name, application_name))
+        kwargs = dict()
+        if source_configuration is not None:
+            if solution_stack is not None:
+                raise AWSError('Must select either source config or '
+                               'solution stack, not both')
+            kwargs['source_configuration_application_name'] = application_name
+            kwargs['source_configuration_template_name'] = source_configuration
+        elif solution_stack is not None:
+            kwargs['solution_stack_name'] = solution_stack
+        else:
+            raise AWSError('Must select either source config or '
+                           'solution stack')
+
+        if option_settings is None:
+            option_settings = []
+        if environ is not None:
+            for key, value in environ.items():
+                option_settings.append((
+                    'aws:elasticbeanstalk:application:environment',
+                    key, value))
+
         self._connection.create_configuration_template(
-            application_name, template_name, solution_stack_name,
-            option_settings=option_settings)
+            application_name, template_name,
+            option_settings=option_settings,
+            **kwargs)
 
-    def _environment_name(self, application_name, environment_name):
-        """Return an environment name
-
-        Generate an environment name from the application name and
-        an environment name. Amazon Beanstalk requires environment names to
-        be unique across applications so the application name must be
-        encoded into the environment name.
-        """
-        return '{}-{}'.format(
-            hashlib.sha1(application_name).hexdigest()[:5],
-            environment_name)
+    def delete_configuration_template(self, application_name, environment_name):
+        logging.info(
+            "Deleting configuration template {}".format(environment_name))
+        self._connection.delete_configuration_template(application_name,
+                                                       environment_name)
 
     def describe_environment(self, application_name, environment_name):
-        environment_name = self._environment_name(
-            application_name, environment_name)
-
         for environment in self.list_environments(application_name):
             if environment['EnvironmentName'] == environment_name:
                 return environment
@@ -199,12 +298,9 @@ class BeanstalkClient(object):
 
         return environments
 
-    def update_environment(self, application_name, environment_name,
-                           version_label):
+    def update_environment(self, environment_name, version_label):
         try:
-            environment_name = self._environment_name(
-                application_name, environment_name)
-            logging.info("Updaing {} to version {}".format(
+            logging.info("Updating {} to version {}".format(
                          environment_name, version_label))
             self._connection.update_environment(
                 environment_name=environment_name,
@@ -215,22 +311,10 @@ class BeanstalkClient(object):
             else:
                 raise
 
-    def create_or_update_environment(self, application_name, environment_name,
-                                     version_label):
+    def terminate_environment(self, environment_name):
         try:
-            self.create_environment(
-                application_name, environment_name, version_label)
-        except BotoServerError as e:
-            if self._environment_already_exists(e):
-                self.update_environment(
-                    application_name, environment_name, version_label)
-            else:
-                raise
-
-    def terminate_environment(self, application_name, environment_name):
-        try:
-            environment_name = self._environment_name(
-                application_name, environment_name)
+            logging.info(
+                "Terminating Beanstalk environment {}".format(environment_name))
             self._connection.terminate_environment(
                 environment_name=environment_name)
         except BotoServerError as e:
@@ -259,6 +343,23 @@ class BeanstalkClient(object):
             if not self._application_version_already_exists(e):
                 raise
 
+    def wait_for_security_group(self, environment_name):
+        while self.get_security_group(environment_name) is None:
+            time.sleep(2)
+
+    def get_security_group(self, environment_name):
+        resources = self._connection.describe_environment_resources(
+            environment_name=environment_name)
+        resources = resources['DescribeEnvironmentResourcesResponse']
+        resources = resources['DescribeEnvironmentResourcesResult']
+        resources = resources['EnvironmentResources']
+        resources = resources['Resources']
+
+        for resource in resources:
+            if resource['Type'] == 'AWS::EC2::SecurityGroup':
+                return self._ec2.get_security_group(
+                    resource['PhysicalResourceId'])
+
     def _application_already_exists(self, e):
         if e.error_code != 'InvalidParameterValue':
             return False
@@ -285,6 +386,98 @@ class BeanstalkClient(object):
         if e.error_code != 'InvalidParameterValue':
             return False
         return re.match(r'Application Version .* already exists.', e.message)
+
+
+class EC2Client(object):
+    def __init__(self, region):
+        self._region = region
+        self._connection = ec2.connect_to_region(region)
+
+    def create_security_group(self, name, description):
+        security_group = self.get_security_group(name)
+        if security_group is None:
+            self._connection.create_security_group(
+                name,
+                'Security group for {} {}'.format(description, name))
+            security_group = self.get_security_group(name)
+
+        return security_group
+
+    def get_security_group(self, security_group_name):
+        for sg in self._connection.get_all_security_groups():
+            if sg.name == security_group_name:
+                return sg
+
+
+class RDSClient(object):
+    def __init__(self, region, **kwargs):
+        self._region = region
+        self._options = kwargs
+        self._connection = rds2.connect_to_region(region)
+        self._ec2 = EC2Client(region)
+
+    @staticmethod
+    def instance_id(environment_name):
+        return 'db-{}'.format(environment_name)
+
+    def create_dbinstance(self, environment_name, db_name, username, password):
+        instance_id = self.instance_id(environment_name)
+
+        security_group = self._ec2.create_security_group(instance_id,
+                                                         'RDS instance')
+        try:
+            dbinstance = self.get_dbinstance(instance_id)
+            if dbinstance is None:
+                self._connection.create_db_instance(
+                    db_instance_identifier=instance_id,
+                    allocated_storage=5,
+                    db_instance_class='db.t1.micro',
+                    engine='postgres',
+                    master_username=username,
+                    master_user_password=password,
+                    db_name=db_name,
+                    backup_retention_period=0,
+                    vpc_security_group_ids=[security_group.id],
+                )
+                dbinstance = self.get_dbinstance(instance_id)
+            return dbinstance
+        except:
+            self.get_security_group(environment_name).delete()
+            raise
+
+    def delete_dbinstance(self, environment_name):
+        logging.info(
+            "Deleting RDS instance {}".format(environment_name))
+        instance_id = self.instance_id(environment_name)
+        # TODO: We should probably take final snapshots for production databases
+        self._connection.delete_db_instance(instance_id,
+                                            skip_final_snapshot=True)
+        logging.info(
+            "Waiting for RDS instance {} to go".format(environment_name))
+        self.wait_for_instance_to_go(instance_id)
+        self.get_security_group(environment_name).delete()
+
+    def wait_for_endpoint(self, dbinstance):
+        while dbinstance.get('Endpoint') is None:
+            dbinstance = self.get_dbinstance(dbinstance['DBInstanceIdentifier'])
+            time.sleep(10)
+        return dbinstance
+
+    def wait_for_instance_to_go(self, instance_id):
+        while self.get_dbinstance(instance_id) is not None:
+            time.sleep(10)
+
+    def get_dbinstance(self, instance_id):
+        dbinstances = self._connection.describe_db_instances()
+        dbinstances = dbinstances['DescribeDBInstancesResponse']
+        dbinstances = dbinstances['DescribeDBInstancesResult']
+        dbinstances = dbinstances['DBInstances']
+        for dbinstance in dbinstances:
+            if dbinstance['DBInstanceIdentifier'] == instance_id:
+                return dbinstance
+
+    def get_security_group(self, environment_name):
+        return self._ec2.get_security_group(self.instance_id(environment_name))
 
 
 class AWSError(StandardError):

--- a/digitalmarketplace/deploy/cli.py
+++ b/digitalmarketplace/deploy/cli.py
@@ -16,10 +16,14 @@ proxy_env_arg = argh.arg(
          "configuration template")
 
 
+@argh.arg('db_name', help='Database name')
+@argh.arg('db_username', help='Master database username')
+@argh.arg('db_password', help='Master database password')
 @proxy_env_arg
-def bootstrap(region=None, proxy_env=None):
+def bootstrap(db_name, db_username, db_password, proxy_env=None, region=None):
     """Create a new application with an S3 bucket and core environments"""
-    aws.get_client(region).bootstrap(proxy_env)
+    aws.get_client(region).bootstrap(proxy_env,
+                                     db_name, db_username, db_password)
 
 
 def create_version(version_label, region=None):
@@ -27,17 +31,17 @@ def create_version(version_label, region=None):
     aws.get_client(region).create_version(version_label)
 
 
-@proxy_env_arg
-def create_configuration(region=None, proxy_env=None):
-    """Create a new configuration template"""
-    aws.get_client(region).create_configuration(proxy_env)
-
-
-def deploy_to_branch_environment(branch=None, region=None):
+@argh.arg('db_name', help='Database name')
+@argh.arg('db_username', help='Master database username')
+@argh.arg('db_password', help='Master database password')
+def deploy_to_branch_environment(db_name, db_username, db_password,
+                                 branch=None, region=None):
     """Deploy the current HEAD to a temporary branch environment"""
     if branch is None:
         branch = git.get_current_branch()
-    aws.get_client(region).deploy_to_branch_environment(branch)
+    aws.get_client(region).deploy_to_branch_environment(branch, db_name,
+                                                        db_username,
+                                                        db_password)
 
 
 def terminate_branch_environment(branch=None, region=None):
@@ -74,7 +78,6 @@ def main():
     parser.add_argument('--region', default='eu-west-1')
     parser.add_commands([
         bootstrap,
-        create_configuration,
         create_version,
         deploy_to_branch_environment,
         terminate_branch_environment,


### PR DESCRIPTION
This is a very large commit, sorry. The full details of the process has
been added to the README so I will just outline what has changed here.

When a new Beanstalk environment is created an RDS instace is also
created. The Beanstalk environment is given acess to this with a
VPC security group. A Beanstalk configuration template is also created
that contains the RDS connection information (in the form of an
SQLAlchemy URI). This is used when creating the Beanstalk environment.

The order of creation is very significant, it goes like this:
- Create RDS security group
- Create RDS instance
- Wait for RDS instance to come up
- Create configuration template with RDS connection details
- Create Beanstalk environment
- Wait for Beanstal environment security group
- Allow access to RDS instance security group from Beanstalk
  environment security group.

We need to wait for the RDS instance to come up so that we can get the
endpoint it lives on to give to the Beanstalk environment. We need to
wait for Beanstalk security group in order to give it access to the RDS
instance. Note that there is a race condition; if the Beanstalk
environment runs the application startup scripts that do database
migration before we've updated the RDS security group it will fail.
Luckily the Beanstalk environment security group seems to be created
very early in the process.

The RDS instance and security group both have 'db-' prefixed to them.
This is because they must start with a letter and the app sha may start
with a number.
