### PR TITLE
Rename ephemeral to development

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,21 +51,21 @@ environment and added to the configuration template::
 
   dm-deploy bootstrap --proxy-env='FOO,BAR'
 
-Ephemeral environments
-~~~~~~~~~~~~~~~~~~~~~~
+Development environments
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-To create an ephemeral environment for a feature branch use the 
-``deploy-to-branch-environment`` command. This will create a development version,
-a development environment with that version and an associated RDS instance. If
-a branch is not explicitly provided then the current branch name will be used::
+To create a development environment (for a feature branch, for example) use the
+``deploy-to-development-environment`` command. This will create a development
+version, a development environment with that version and an associated RDS
+instance. A name for the development environment must be provided as the first
+argument::
 
-  dm-deploy deploy-to-branch-environment
+  dm-deploy deploy-to-development-environment my-feature db_name db_user db_password
 
-When the ephemeral environment is no longer needed it can be removed with
-the ``terminate-branch-environment`` command. If a branch is not explicitly
-provided then the current branch name will be used::
+When the development environment is no longer needed it can be removed with
+the ``terminate-development-environment`` command::
 
-  dm-deploy terminate-branch-environment
+  dm-deploy terminate-development-environment my-feature
 
 Deployment
 ~~~~~~~~~~
@@ -120,7 +120,7 @@ Beanstalk environments are named ``{app sha}-{environment short name}``.
 because environment names must be unique across all Beanstalk applications.
 ``{environment short name}`` is the environment name we use; for example
 ``staging`` or ``production`` for our permanent environments or ``dev-{label}``
-for ephemeral environments.
+for development environments.
 
 Each environment has it's own RDS instance associated with it, see
 `RDS instance`_.
@@ -165,7 +165,7 @@ application a version called ``initial`` is created all other versions are
 named as follows:
 
 - Release versions should be called ``release-{build number}``.
-- Ephemeral versions will be called ``dev-{label}-{short commit sha}``.
+- Development versions will be called ``dev-{label}-{short commit sha}``.
 
 .. note::
   Version names have a length limit of 100 characters.

--- a/digitalmarketplace/deploy/aws.py
+++ b/digitalmarketplace/deploy/aws.py
@@ -65,9 +65,9 @@ class Client(object):
             description)
         return version_label
 
-    def deploy_to_branch_environment(self, branch, db_name, db_username,
-                                     db_password):
-        environment_short_name = 'dev-{}'.format(branch)
+    def deploy_to_development_environment(self, name, db_name, db_username,
+                                          db_password):
+        environment_short_name = 'dev-{}'.format(name)
         environment_name = self._get_env_name(environment_short_name)
         version_label = self.create_version(
             environment_short_name, with_sha=True)
@@ -79,8 +79,8 @@ class Client(object):
             self.beanstalk.update_environment(environment_name,
                                               version_label)
 
-    def terminate_branch_environment(self, branch):
-        environment_short_name = 'dev-{}'.format(branch)
+    def terminate_development_environment(self, name):
+        environment_short_name = 'dev-{}'.format(name)
         environment_name = self._get_env_name(environment_short_name)
 
         self.beanstalk.terminate_environment(environment_name)

--- a/digitalmarketplace/deploy/cli.py
+++ b/digitalmarketplace/deploy/cli.py
@@ -31,24 +31,22 @@ def create_version(version_label, region=None):
     aws.get_client(region).create_version(version_label)
 
 
+@argh.arg('name', help='Name for the environment')
 @argh.arg('db_name', help='Database name')
 @argh.arg('db_username', help='Master database username')
 @argh.arg('db_password', help='Master database password')
-def deploy_to_branch_environment(db_name, db_username, db_password,
-                                 branch=None, region=None):
-    """Deploy the current HEAD to a temporary branch environment"""
-    if branch is None:
-        branch = git.get_current_branch()
-    aws.get_client(region).deploy_to_branch_environment(branch, db_name,
-                                                        db_username,
-                                                        db_password)
+def deploy_to_development_environment(name, db_name, db_username, db_password,
+                                      region=None):
+    """Deploy the current HEAD to a temporary development environment"""
+    aws.get_client(region).deploy_to_development_environment(name, db_name,
+                                                             db_username,
+                                                             db_password)
 
 
-def terminate_branch_environment(branch=None, region=None):
-    """Terminate a temporary branch environment"""
-    if branch is None:
-        branch = git.get_current_branch()
-    aws.get_client(region).terminate_branch_environment(branch)
+@argh.arg('name', help='Name for the environment')
+def terminate_development_environment(name, region=None):
+    """Terminate a temporary development environment"""
+    aws.get_client(region).terminate_development_environment(name)
 
 
 def deploy_latest_to_staging(region=None):
@@ -79,8 +77,8 @@ def main():
     parser.add_commands([
         bootstrap,
         create_version,
-        deploy_to_branch_environment,
-        terminate_branch_environment,
+        deploy_to_development_environment,
+        terminate_development_environment,
         deploy_latest_to_staging,
         deploy_staging_to_production,
         deploy_to_staging,


### PR DESCRIPTION
Depends on #3 

It wasn't clear what these environments were actually for. Also, because
these environments are a bit more costly to create now that we have an
RDS instance attached to each environment it probably doesn't make sense
to have the binding to feature branches quite so tight.

Now a development environment must be given a name when it's created.
Nothing else about it being on a branch is assumed.
